### PR TITLE
Add environment.yml for use with conda env create

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,11 @@ Supported Platforms:
 
 ## Install
 
-You can get miniconda from https://docs.conda.io/en/latest/miniconda.html, or install the dependencies shown below manually.
+You can get miniconda from https://docs.conda.io/en/latest/miniconda.html and use `environment.yml` to install dependencies
 
 ```
-conda create --name image-gpt python=3.7.3
+conda env create -f environment.yml
 conda activate image-gpt
-
-conda install numpy=1.16.3
-conda install tensorflow-gpu=1.13.1
-
-conda install imageio=2.8.0
-conda install requests=2.21.0
-conda install tqdm=4.46.0
 ```
 
 ## Usage

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: image-gpt
+dependencies:
+    - python=3.7.3
+    - numpy=1.16.3
+    - tensorflow-gpu=1.13.1
+    - imageio=2.8.0
+    - requests=2.21.0
+    - tqdm=4.46.0


### PR DESCRIPTION
Just starting to play around and all of the CLI code is working great!

To streamline the setup even further (but not quite *Docker* far), I created an `environment.yml` that enables a one-line install in conda (see updated README). This way you only have one file to update if/as requirements change.

Instead of manually typing out an environment name and installing each requirement, we can now just run

```
conda env create -f environment.yml
``` 